### PR TITLE
Fix sticky dropdown overlap on mobile

### DIFF
--- a/src/Components/Skills.js
+++ b/src/Components/Skills.js
@@ -90,11 +90,11 @@ const Skills = ({ data }) => {
                     margin: '24px 0 32px 0',
                     borderBottom: isMobile ? 'none' : '2px solid #232323',
                     background: '#2B2B2B',
-                    zIndex: 1,
+                    zIndex: 101,
                     paddingTop: 8,
                     paddingBottom: 8,
                     marginBottom: 24,
-                    ...(isMobile ? { position: 'sticky', top: 0 } : {}),
+                    ...(isMobile ? { position: 'sticky', top: 60 } : {}),
                 }}>
                     {isMobile ? (
                         <select


### PR DESCRIPTION
## Summary
- keep tech category dropdown below mobile nav

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e27e80cf8832aa25035a95235460d